### PR TITLE
Update runtime lib search path to find deps

### DIFF
--- a/macos/usdview.xcodeproj/project.pbxproj
+++ b/macos/usdview.xcodeproj/project.pbxproj
@@ -524,8 +524,8 @@
 				INFOPLIST_FILE = usdview/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
+					"$(PROJECT_DIR)/deps/lib",
 					"@executable_path/../Frameworks",
-					"/tmp/usdview-native/deps/lib/",
 				);
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
@@ -551,8 +551,8 @@
 				INFOPLIST_FILE = usdview/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
+					"$(PROJECT_DIR)/deps/lib",
 					"@executable_path/../Frameworks",
-					"/tmp/usdview-native/deps/lib/",
 				);
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",


### PR DESCRIPTION
Fixes a runtime failure when launching the app due to not finding the libraries to link against (grumble grumble I wish we could have a static build).